### PR TITLE
Fix toggle for status update checks

### DIFF
--- a/src/commands/command.rs
+++ b/src/commands/command.rs
@@ -1,0 +1,42 @@
+use serenity::async_trait;
+use serenity::model::prelude::*;
+use serenity::prelude::*;
+use std::collections::HashSet;
+use std::fs::{OpenOptions};
+use std::io::{self, Write};
+
+#[async_trait]
+impl Command for ToggleExclusionCommand {
+    fn name(&self) -> &str {
+        "toggle_exclusion"
+    }
+
+    fn description(&self) -> &str {
+        "Toggles exclusion of a user from the status update report."
+    }
+
+    async fn execute(&self, ctx: &Context, msg: &Message) -> anyhow::Result<()> {
+        let args: Vec<String> = msg.content.split_whitespace().map(|s| s.to_string()).collect();
+        if args.len() < 2 {
+            msg.reply(ctx, "Please specify a user to toggle exclusion").await?;
+            return Ok(());
+        }
+        let user_id = args[1].parse::<u64>().unwrap_or(0);
+        if user_id == 0 {
+            msg.reply(ctx, "Invalid user ID").await?;
+            return Ok(());
+        }
+
+        let mut excluded_members = get_excluded_members()?;
+        if excluded_members.contains(&user_id) {
+            excluded_members.remove(&user_id);
+            msg.reply(ctx, "User has been removed from the exclusion list").await?;
+        } else {
+            excluded_members.insert(user_id);
+            msg.reply(ctx, "User has been added to the exclusion list").await?;
+        }
+
+        save_excluded_members(excluded_members)?;
+        Ok(())
+    }
+}

--- a/src/utils/storage.rs
+++ b/src/utils/storage.rs
@@ -1,0 +1,27 @@
+use std::collections::HashSet;
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufRead, Write};
+use std::path::Path;
+
+pub fn get_excluded_members() -> io::Result<HashSet<u64>> {
+    let path = Path::new("excluded_members.json");
+    let file = OpenOptions::new().read(true).create(true).open(path)?;
+    let reader = io::BufReader::new(file);
+    let excluded_members = reader
+        .lines()
+        .filter_map(|line| line.ok().and_then(|l| l.parse::<u64>().ok()))
+        .collect::<HashSet<u64>>();
+
+    Ok(excluded_members)
+}
+
+pub fn save_excluded_members(excluded_members: HashSet<u64>) -> io::Result<()> {
+    let path = Path::new("excluded_members.json");
+    let mut file = OpenOptions::new().write(true).create(true).truncate(true).open(path)?;
+
+    for user_id in excluded_members {
+        writeln!(file, "{}", user_id)?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #29  
2 new files have been added which are command.rs and storage.rs which are for implementing a command and storing the usernames respectively, and function status_updates_check has some lines added which will exclude the members when checking for status updates. This command can be registered in the main and can be used to exclude some members with their user id's. 