### PR TITLE
Fix deserialization error in AttendanceRecord struct

### DIFF
--- a/src/graphql/models.rs
+++ b/src/graphql/models.rs
@@ -50,7 +50,6 @@ pub struct Member {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct AttendanceRecord {
-    #[serde(rename = "memberId")]
     pub name: String,
     pub year: i32,
     #[serde(rename = "isPresent")]


### PR DESCRIPTION
Fixed a bug in the AttendanceRecord struct that was causing "Failed to fetch attendance from Root" errors in the logs. The API response includes a "name" field, but I had accidentally left a `#[serde(rename = "memberId")]` annotation on the name field, causing deserialization to fail.

This PR simply removes the incorrect annotation so the struct properly maps to the API response.