### PR TITLE
Status updates can now be identified using Namashivaya

### DIFF
--- a/src/tasks/status_update.rs
+++ b/src/tasks/status_update.rs
@@ -137,7 +137,7 @@ fn get_report_config() -> ReportConfig {
 
     ReportConfig {
         time_valid_from,
-        keywords: vec!["namah shivaya", "regards"],
+        keywords: vec!["namah shivaya", "namashivaya", "regards"],
         special_authors: vec![AMAN_SHAFEEQ, CHANDRA_MOULI],
     }
 }


### PR DESCRIPTION
This PR fixes issue #59 by introducing support to identify keyword "Namashivaya" in status updates.

Changes made in /src/tasks/status_updates.rs