### PR TITLE
Use webhooks to mirror status updates with member identity

### DIFF
--- a/src/tasks/status_update_mirror.rs
+++ b/src/tasks/status_update_mirror.rs
@@ -81,19 +81,16 @@ pub async fn mirror_new_updates(ctx: ClientContext, client: GraphQLClient) -> an
             if member.track.is_none() || member.group_id.is_none() {
                 continue;
             }
-            if let Some(discord_id) = &member.discord_id {
-                let discord_id: u64 = discord_id.parse()?;
 
-                send_update(
-                    &ctx,
-                    member.name.clone(),
-                    discord_id,
-                    member.track.clone().unwrap(),
-                    member.group_id.unwrap(),
-                    email.body.clone(),
-                )
-                .await?;
-            }
+            send_update(
+                &ctx,
+                member.name.clone(),
+                member.discord_id.as_deref(),
+                member.track.clone().unwrap(),
+                member.group_id.unwrap(),
+                email.body.clone(),
+            )
+            .await?;
         }
     }
     Ok(())
@@ -148,10 +145,31 @@ async fn get_avatar_url(ctx: &ClientContext, discord_id: u64) -> anyhow::Result<
     Ok(avatar)
 }
 
+async fn get_bot_avatar_url(ctx: &ClientContext) -> anyhow::Result<String> {
+    let bot_user = ctx.http.get_current_user().await?;
+
+    Ok(bot_user
+        .avatar_url()
+        .unwrap_or_else(|| bot_user.default_avatar_url()))
+}
+
+async fn resolve_avatar_url(
+    ctx: &ClientContext,
+    discord_id: Option<&str>,
+) -> anyhow::Result<String> {
+    match discord_id {
+        Some(id_str) => match id_str.parse::<u64>() {
+            Ok(id) => get_avatar_url(ctx, id).await,
+            Err(_) => get_bot_avatar_url(ctx).await,
+        },
+        None => get_bot_avatar_url(ctx).await,
+    }
+}
+
 async fn send_update(
     ctx: &ClientContext,
     name: String,
-    discord_id: u64,
+    discord_id: Option<&str>,
     track: String,
     group: i32,
     content: String,
@@ -170,7 +188,7 @@ async fn send_update(
 
     let channel = ChannelId::new(channel_id);
 
-    let avatar_url = get_avatar_url(ctx, discord_id).await?;
+    let avatar_url = resolve_avatar_url(ctx, discord_id).await?;
 
     send_webhook_message(ctx, channel, name, avatar_url, content).await?;
 

--- a/src/tasks/status_update_mirror.rs
+++ b/src/tasks/status_update_mirror.rs
@@ -19,12 +19,12 @@ use super::Task;
 use crate::graphql::GraphQLClient;
 use anyhow::Context;
 use async_trait::async_trait;
-use serenity::client::Context as ClientContext;
-use serenity::prelude::CacheHttp;
-use serenity::model::webhook::Webhook;
 use serenity::builder::CreateWebhook;
 use serenity::builder::ExecuteWebhook;
-use serenity::model::id::{UserId};
+use serenity::client::Context as ClientContext;
+use serenity::model::id::UserId;
+use serenity::model::webhook::Webhook;
+use serenity::prelude::CacheHttp;
 use std::collections::HashMap;
 
 pub struct MirrorNewUpdates;
@@ -82,18 +82,18 @@ pub async fn mirror_new_updates(ctx: ClientContext, client: GraphQLClient) -> an
                 continue;
             }
             if let Some(discord_id) = &member.discord_id {
-            let discord_id: u64 = discord_id.parse()?;
+                let discord_id: u64 = discord_id.parse()?;
 
-            send_update(
-                &ctx,
-                member.name.clone(),
-                discord_id,
-                member.track.clone().unwrap(),
-                member.group_id.unwrap(),
-                email.body.clone(),
-            )
-            .await?;
-        }
+                send_update(
+                    &ctx,
+                    member.name.clone(),
+                    discord_id,
+                    member.track.clone().unwrap(),
+                    member.group_id.unwrap(),
+                    email.body.clone(),
+                )
+                .await?;
+            }
         }
     }
     Ok(())
@@ -103,10 +103,12 @@ async fn get_or_create_webhook(
     ctx: &ClientContext,
     channel_id: ChannelId,
 ) -> anyhow::Result<Webhook> {
-
     let hooks = channel_id.webhooks(ctx.http()).await?;
 
-    if let Some(hook) = hooks.into_iter().find(|h| h.name == Some("amD Updates".to_string())) {
+    if let Some(hook) = hooks
+        .into_iter()
+        .find(|h| h.name == Some("amD Updates".to_string()))
+    {
         return Ok(hook);
     }
 
@@ -124,7 +126,6 @@ async fn send_webhook_message(
     avatar_url: String,
     content: String,
 ) -> anyhow::Result<()> {
-
     let webhook = get_or_create_webhook(ctx, channel_id).await?;
 
     let builder = ExecuteWebhook::new()
@@ -137,11 +138,7 @@ async fn send_webhook_message(
     Ok(())
 }
 
-async fn get_avatar_url(
-    ctx: &ClientContext,
-    discord_id: u64,
-) -> anyhow::Result<String> {
-
+async fn get_avatar_url(ctx: &ClientContext, discord_id: u64) -> anyhow::Result<String> {
     let user = ctx.http.get_user(UserId::new(discord_id)).await?;
 
     let avatar = user
@@ -175,13 +172,7 @@ async fn send_update(
 
     let avatar_url = get_avatar_url(ctx, discord_id).await?;
 
-    send_webhook_message(
-        ctx,
-        channel,
-        name,
-        avatar_url,
-        content,
-    ).await?;
+    send_webhook_message(ctx, channel, name, avatar_url, content).await?;
 
     Ok(())
 }

--- a/src/tasks/status_update_mirror.rs
+++ b/src/tasks/status_update_mirror.rs
@@ -21,6 +21,10 @@ use anyhow::Context;
 use async_trait::async_trait;
 use serenity::client::Context as ClientContext;
 use serenity::prelude::CacheHttp;
+use serenity::model::webhook::Webhook;
+use serenity::builder::CreateWebhook;
+use serenity::builder::ExecuteWebhook;
+use serenity::model::id::{UserId};
 use std::collections::HashMap;
 
 pub struct MirrorNewUpdates;
@@ -30,8 +34,6 @@ use chrono::{Datelike, Duration, Local, Timelike};
 use chrono_tz::Asia::Kolkata;
 use mailparse::{MailHeaderMap, ParsedMail};
 use poise::serenity_prelude::ChannelId;
-use poise::serenity_prelude::CreateEmbed;
-use poise::serenity_prelude::CreateMessage;
 
 pub struct EmailDetails {
     pub from: String,
@@ -79,22 +81,80 @@ pub async fn mirror_new_updates(ctx: ClientContext, client: GraphQLClient) -> an
             if member.track.is_none() || member.group_id.is_none() {
                 continue;
             }
+            if let Some(discord_id) = &member.discord_id {
+            let discord_id: u64 = discord_id.parse()?;
+
             send_update(
                 &ctx,
                 member.name.clone(),
+                discord_id,
                 member.track.clone().unwrap(),
                 member.group_id.unwrap(),
                 email.body.clone(),
             )
             .await?;
         }
+        }
     }
     Ok(())
+}
+
+async fn get_or_create_webhook(
+    ctx: &ClientContext,
+    channel_id: ChannelId,
+) -> anyhow::Result<Webhook> {
+
+    let hooks = channel_id.webhooks(ctx.http()).await?;
+
+    if let Some(hook) = hooks.into_iter().find(|h| h.name == Some("amD Updates".to_string())) {
+        return Ok(hook);
+    }
+
+    let webhook = channel_id
+        .create_webhook(ctx.http(), CreateWebhook::new("amD Updates"))
+        .await?;
+
+    Ok(webhook)
+}
+
+async fn send_webhook_message(
+    ctx: &ClientContext,
+    channel_id: ChannelId,
+    username: String,
+    avatar_url: String,
+    content: String,
+) -> anyhow::Result<()> {
+
+    let webhook = get_or_create_webhook(ctx, channel_id).await?;
+
+    let builder = ExecuteWebhook::new()
+        .username(username)
+        .avatar_url(avatar_url)
+        .content(content);
+
+    webhook.execute(ctx.http(), false, builder).await?;
+
+    Ok(())
+}
+
+async fn get_avatar_url(
+    ctx: &ClientContext,
+    discord_id: u64,
+) -> anyhow::Result<String> {
+
+    let user = ctx.http.get_user(UserId::new(discord_id)).await?;
+
+    let avatar = user
+        .avatar_url()
+        .unwrap_or_else(|| user.default_avatar_url());
+
+    Ok(avatar)
 }
 
 async fn send_update(
     ctx: &ClientContext,
     name: String,
+    discord_id: u64,
     track: String,
     group: i32,
     content: String,
@@ -111,14 +171,17 @@ async fn send_update(
         _ => STATUS_UPDATE_CHANNEL_ID,
     };
 
-    let embed = CreateEmbed::new()
-        .title(format!("Status Update: {}", name))
-        .description(content);
-
-    let msg = CreateMessage::new().embed(embed);
-
     let channel = ChannelId::new(channel_id);
-    channel.send_message(ctx.http(), msg).await?;
+
+    let avatar_url = get_avatar_url(ctx, discord_id).await?;
+
+    send_webhook_message(
+        ctx,
+        channel,
+        name,
+        avatar_url,
+        content,
+    ).await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Description
This updates the status update mirroring to use Discord webhooks instead of bot embeds, the status updates are sent impersonating the member, making it easier to recognize.

## Changes
- Fetches member avatar using their discord_id
- Send updates using webhook with member username and avatar
- Removed embed-based status update messages

## References
Closes #101 

_Manual verificationwas performed in my local testing environment_