### PR TITLE
feat: persist and restore Discord member roles on rejoin

### DIFF
--- a/src/graphql/queries.rs
+++ b/src/graphql/queries.rs
@@ -147,8 +147,11 @@ impl GraphQLClient {
         Ok(attendance)
     }
 
-    pub async fn save_member_roles( &self, discord_id: String, roles: Vec<String>,) -> anyhow::Result<()> {
-
+    pub async fn save_member_roles(
+        &self,
+        discord_id: String,
+        roles: Vec<String>,
+    ) -> anyhow::Result<()> {
         let query = r#"
         mutation($discordId: String!, $roles: [String!]!) {
             saveMemberRoles(discordId: $discordId, roles: $roles)
@@ -159,19 +162,27 @@ impl GraphQLClient {
             "roles": roles
         });
 
-        let res = self.http()
-        .post(self.root_url())
-        .bearer_auth(self.api_key())
-        .json(&serde_json::json!({
-            "query": query,
-            "variables": variables
-        }))
-        .send()
-        .await?;        
+        let res = self
+            .http()
+            .post(self.root_url())
+            .bearer_auth(self.api_key())
+            .json(&serde_json::json!({
+                "query": query,
+                "variables": variables
+            }))
+            .send()
+            .await?
+            .error_for_status()?;
+
+        let response: serde_json::Value = res.json().await?;
+
+        if response.get("errors").is_some() {
+            anyhow::bail!("GraphQL error: {:?}", response["errors"]);
+        }
         Ok(())
     }
 
-    pub async fn get_member_roles( &self, discord_id: String,) -> anyhow::Result<Vec<String>> {
+    pub async fn get_member_roles(&self, discord_id: String) -> anyhow::Result<Vec<String>> {
         let query = r#"
         query($discordId: String!) {
             memberRoles(discordId: $discordId)
@@ -181,7 +192,8 @@ impl GraphQLClient {
             "discordId": discord_id
         });
 
-        let response = self.http()
+        let response = self
+            .http()
             .post(self.root_url())
             .bearer_auth(self.api_key())
             .json(&serde_json::json!({
@@ -193,16 +205,14 @@ impl GraphQLClient {
             .json::<serde_json::Value>()
             .await?;
 
-        //remove @everyone role, a defult role that every member has and is not useful for our purposes. It has the same ID as the guild, so we can filter it out by comparing with the guild ID.
+        // Collect roles returned by the API as strings; any filtering (e.g. removing @everyone) is handled by the caller.
         let roles = response["data"]["memberRoles"]
             .as_array()
             .unwrap_or(&vec![])
             .iter()
-            .filter_map(|v| v.as_str()) 
+            .filter_map(|v| v.as_str())
             .map(|s| s.to_string())
             .collect();
-
         Ok(roles)
     }
-
 }

--- a/src/graphql/queries.rs
+++ b/src/graphql/queries.rs
@@ -146,4 +146,63 @@ impl GraphQLClient {
         );
         Ok(attendance)
     }
+
+    pub async fn save_member_roles( &self, discord_id: String, roles: Vec<String>,) -> anyhow::Result<()> {
+
+        let query = r#"
+        mutation($discordId: String!, $roles: [String!]!) {
+            saveMemberRoles(discordId: $discordId, roles: $roles)
+        }"#;
+
+        let variables = serde_json::json!({
+            "discordId": discord_id,
+            "roles": roles
+        });
+
+        let res = self.http()
+        .post(self.root_url())
+        .bearer_auth(self.api_key())
+        .json(&serde_json::json!({
+            "query": query,
+            "variables": variables
+        }))
+        .send()
+        .await?;        
+        Ok(())
+    }
+
+    pub async fn get_member_roles( &self, discord_id: String,) -> anyhow::Result<Vec<String>> {
+        let query = r#"
+        query($discordId: String!) {
+            memberRoles(discordId: $discordId)
+        }"#;
+
+        let variables = serde_json::json!({
+            "discordId": discord_id
+        });
+
+        let response = self.http()
+            .post(self.root_url())
+            .bearer_auth(self.api_key())
+            .json(&serde_json::json!({
+                "query": query,
+                "variables": variables
+            }))
+            .send()
+            .await?
+            .json::<serde_json::Value>()
+            .await?;
+
+        //remove @everyone role, a defult role that every member has and is not useful for our purposes. It has the same ID as the guild, so we can filter it out by comparing with the guild ID.
+        let roles = response["data"]["memberRoles"]
+            .as_array()
+            .unwrap_or(&vec![])
+            .iter()
+            .filter_map(|v| v.as_str()) 
+            .map(|s| s.to_string())
+            .collect();
+
+        Ok(roles)
+    }
+
 }

--- a/src/graphql/queries.rs
+++ b/src/graphql/queries.rs
@@ -182,10 +182,16 @@ impl GraphQLClient {
         Ok(())
     }
 
-    pub async fn get_member_roles(&self, discord_id: String) -> anyhow::Result<Vec<String>> {
+    pub async fn get_member_roles(
+        &self,
+        discord_id: String,
+    ) -> anyhow::Result<(bool, Vec<String>)> {
         let query = r#"
         query($discordId: String!) {
-            memberRoles(discordId: $discordId)
+            memberRoles(discordId: $discordId){
+                exists
+                roles
+            }
         }"#;
 
         let variables = serde_json::json!({
@@ -206,13 +212,17 @@ impl GraphQLClient {
             .await?;
 
         // Collect roles returned by the API as strings; any filtering (e.g. removing @everyone) is handled by the caller.
-        let roles = response["data"]["memberRoles"]
+        let data = &response["data"]["memberRoles"];
+
+        let exists = data["exists"].as_bool().unwrap_or(false);
+
+        let roles = data["roles"]
             .as_array()
             .unwrap_or(&vec![])
             .iter()
             .filter_map(|v| v.as_str())
             .map(|s| s.to_string())
             .collect();
-        Ok(roles)
+        Ok((exists, roles))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,9 @@ fn prepare_data(config: &Config, reload_handle: ReloadHandle) -> Data {
 async fn build_client(config: &Config, data: Data) -> Result<Client, anyhow::Error> {
     ClientBuilder::new(
         config.discord_token.clone(),
-        GatewayIntents::non_privileged() | GatewayIntents::MESSAGE_CONTENT | GatewayIntents::GUILD_MEMBERS,
+        GatewayIntents::non_privileged()
+            | GatewayIntents::MESSAGE_CONTENT
+            | GatewayIntents::GUILD_MEMBERS,
     )
     .framework(build_framework(
         config.owner_id,
@@ -161,29 +163,38 @@ async fn event_handler(
             handle_reaction(ctx, removed_reaction, data, false).await?;
         }
 
-        FullEvent::GuildMemberRemoval { guild_id: _, user, member_data_if_available } => {
+        FullEvent::GuildMemberRemoval {
+            guild_id: _,
+            user,
+            member_data_if_available: Some(member),
+        } => {
+            let roles: Vec<String> = member
+                .roles
+                .iter()
+                .filter(|r| r.get() != member.guild_id.get())
+                .map(|r| r.get().to_string())
+                .collect();
 
-            if let Some(member) = member_data_if_available {
-
-                let roles: Vec<String> = member.roles
-                    .iter()
-                    .filter(|r| r.get() != member.guild_id.get())
-                    .map(|r| r.get().to_string())
-                    .collect();
-
-                if !roles.is_empty() {
-                    data.graphql_client
-                        .save_member_roles(user.id.to_string(), roles)
-                        .await?;
-                }
+            if let Err(e) = data
+                .graphql_client
+                .save_member_roles(user.id.to_string(), roles)
+                .await
+            {
+                println!("Failed to save roles: {:?}", e);
             }
         }
         FullEvent::GuildMemberAddition { new_member } => {
-
-            let roles = data
+            let roles = match data
                 .graphql_client
                 .get_member_roles(new_member.user.id.to_string())
-                .await?;
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    println!("Failed to fetch roles for {}: {:?}", new_member.user.id, e);
+                    Vec::new()
+                }
+            };
 
             for role in roles {
                 if let Ok(role_id) = role.parse::<u64>() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,21 +184,28 @@ async fn event_handler(
             }
         }
         FullEvent::GuildMemberAddition { new_member } => {
-            let roles = match data
+            let (exists, roles) = match data
                 .graphql_client
                 .get_member_roles(new_member.user.id.to_string())
                 .await
             {
                 Ok(r) => r,
                 Err(e) => {
-                    println!("Failed to fetch roles for {}: {:?}", new_member.user.id, e);
-                    Vec::new()
+                    println!("Failed to fetch roles: {:?}", e);
+                    (false, vec![])
                 }
             };
 
-            for role in roles {
-                if let Ok(role_id) = role.parse::<u64>() {
-                    let _ = new_member.add_role(ctx, RoleId::new(role_id)).await;
+            if let Ok(member) = new_member.guild_id.member(ctx, new_member.user.id).await {
+                // restore roles
+                for role in roles {
+                    if let Ok(role_id) = role.parse::<u64>() {
+                        let _ = member.add_role(ctx, RoleId::new(role_id)).await;
+                    }
+                }
+                // probated role
+                if exists {
+                    let _ = member.add_role(ctx, RoleId::new(1484798446228475905)).await;
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ fn prepare_data(config: &Config, reload_handle: ReloadHandle) -> Data {
 async fn build_client(config: &Config, data: Data) -> Result<Client, anyhow::Error> {
     ClientBuilder::new(
         config.discord_token.clone(),
-        GatewayIntents::non_privileged() | GatewayIntents::MESSAGE_CONTENT,
+        GatewayIntents::non_privileged() | GatewayIntents::MESSAGE_CONTENT | GatewayIntents::GUILD_MEMBERS,
     )
     .framework(build_framework(
         config.owner_id,
@@ -159,6 +159,37 @@ async fn event_handler(
         }
         FullEvent::ReactionRemove { removed_reaction } => {
             handle_reaction(ctx, removed_reaction, data, false).await?;
+        }
+
+        FullEvent::GuildMemberRemoval { guild_id: _, user, member_data_if_available } => {
+
+            if let Some(member) = member_data_if_available {
+
+                let roles: Vec<String> = member.roles
+                    .iter()
+                    .filter(|r| r.get() != member.guild_id.get())
+                    .map(|r| r.get().to_string())
+                    .collect();
+
+                if !roles.is_empty() {
+                    data.graphql_client
+                        .save_member_roles(user.id.to_string(), roles)
+                        .await?;
+                }
+            }
+        }
+        FullEvent::GuildMemberAddition { new_member } => {
+
+            let roles = data
+                .graphql_client
+                .get_member_roles(new_member.user.id.to_string())
+                .await?;
+
+            for role in roles {
+                if let Ok(role_id) = role.parse::<u64>() {
+                    let _ = new_member.add_role(ctx, RoleId::new(role_id)).await;
+                }
+            }
         }
         _ => {}
     }


### PR DESCRIPTION
## Overview

Adds functionality to automatically persist a member's Discord roles when they leave the server and restore them when they rejoin.

Currently, when a user leaves and joins again, all their roles are lost and moderators must manually reassign them. This change automates that process.

## How it works

- When a member leaves (`GuildMemberRemoval`), their role IDs are collected and saved via the Root backend.
- When the member rejoins (`GuildMemberAddition`), the bot fetches the stored roles and restores them automatically.

## Notes

- The `@everyone` role is excluded since it is implicitly assigned by Discord.
- Role restoration errors (e.g., deleted roles or permission issues) are safely ignored to avoid breaking the event handler.

## Related PR

This feature depends on the supporting backend changes in **root**:

➡ Supporting PR: [`pr link`](https://github.com/amfoss/root/pull/171)
Closes #93
